### PR TITLE
Add parameter to `x-on` modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Provides two way data binding to a input/textarea/select/details. It listens to 
 ```
 
 The following example works exactly the same as the one above
+
 ```html
 <input x-on:input="text = $el.target.value" x-bind:value="text" />
 ```

--- a/README.md
+++ b/README.md
@@ -163,23 +163,30 @@ Binds an event listener with optional modifiers.
 </div>
 ```
 
-#### Available modifiers
+#### Modifiers
 
-- **once**: Runs the expression only once
+- **once**: Runs only once
 - **self**: Runs the expression only if `event.target` equals to `event.currentTarget`
 - **left**, **middle**, **right**: Filter mouse clicks
-- **prevent**: Runs `event.preventDefault()` before executing the expression
-- **stop**: Runs `event.stopPropagation()` before executing the expression
+- **prevent**: Runs `event.preventDefault()`
+- **stop**: Runs `event.stopPropagation()`
+- **stopImmediate**: Runs `event.stopImmediatePropagation()`
 
-#### Future plans
+#### Modifiers with parameters
 
-At some point, I'd like to add an option to provide parameters to the modifiers. For instance it would be quite useful, if we could debounce event listeners, or limit the number of times an expression is called:
+You can provide a single parameter to the modifier using this syntax. You can also pass in a defined in the `x-scope` and `x-data`. Note: it does not accept expressions, only variables/primitive values.
 
 ```html
-<div x-on:click.only[10]="doSomething()" />
-<!-- Debounce to 50ms and use the trailing expression call (default is leading) -->
-<div x-on:mouseover.debounce[50, false]="doSomething()" />
+<button x-on:click.only[5]="doNothingAfterFiveClicks()" />
+
+<div x-scope="{ limit: 5 }">
+  <button x-on:click.only[limit]="doNothingAfterFiveClicks()" />
+</div>
 ```
+
+- **only** (default=1): Run until the provided amount is reached
+- **if**: Runs if the provided value is truthy
+- **throttle**: (default=300) Limits the amount of calls within the specified timeframe in milliseconds
 
 ### `x-model`
 

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
   </head>
   <body>
     <div id="app">
-      <div x-scope="{ count: 10 }">
-        <button x-on:click="test()">Click me please</button>
+      <div x-scope>
+        <button x-on:click.debounce[1000]="test()">Click me please</button>
       </div> 
     </div>
     <script type="module">

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <body>
     <div id="app">
       <div x-scope>
-        <button x-on:click.debounce[1000]="test()">Click me please</button>
+        <button x-on:click.throttle[1000]="test()">Click me please</button>
       </div> 
     </div>
     <script type="module">

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -7,3 +7,17 @@ export type Directive = (
 ) => void
 
 export const customDirectives: Record<string, Directive> = {}
+
+export interface ModifierListenerState {
+  calledTimes: number
+  lastCall: number
+}
+
+export type Primitive = string | number | null | undefined | boolean | bigint
+
+export interface Modifier {
+  key: string
+  param: Primitive
+}
+
+export type ModifierFn = (e: Event, state: ModifierListenerState, parameter: Primitive) => boolean

--- a/src/directives/x-on.ts
+++ b/src/directives/x-on.ts
@@ -2,8 +2,6 @@ import { evaluate, execute } from '../evaluate'
 import type { Directive, Modifier, ModifierFn, ModifierListenerState, Primitive } from '.'
 
 export const eventModifiers: Record<string, ModifierFn> = {
-  // REVIEW
-  // Figure out if leading / trailing options are needed
   throttle: (_, { lastCall }, amount = 300) => {
     if (typeof amount !== 'number')
       return false

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,5 @@
+import type { Primitive } from '@vue/reactivity'
+
 export function isSibling(el: HTMLElement, el2: HTMLElement) {
   return el !== el2 && el.parentNode === el2.parentNode
 }
@@ -23,4 +25,9 @@ export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, 
 export function removeChildren(node: Element) {
   while (node.lastElementChild)
     node.removeChild(node.lastElementChild)
+}
+
+export function isType(val: any, requiredType: Primitive) {
+  // eslint-disable-next-line valid-typeof
+  return typeof val === requiredType
 }

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,8 +1,9 @@
 import { reactive } from '@vue/reactivity'
 import { Context } from './context'
-import type { Directive } from './directives'
+import type { Directive, ModifierFn } from './directives'
 import { customDirectives } from './directives'
 import { walk } from './walker'
+import { eventModifiers } from './directives/x-on'
 
 export const globalState = reactive({})
 
@@ -11,11 +12,34 @@ class App<T extends object> {
     Object.assign(globalState, initialDataset)
   }
 
+  /**
+   * Add a custom directive (element attribute)
+   *
+   * @param name Directive name, preferably should start with `x-`
+   * @param fn Directive implementation
+   */
   directive(name: string, fn: Directive) {
     customDirectives[name] = fn
     return this
   }
 
+  /**
+   * Add a custom x-on event modifier
+   *
+   * @param name Modifier name
+   * @param fn Modifier implementation
+   */
+  modifier(name: string, fn: ModifierFn) {
+    if (name in eventModifiers)
+      throw new Error(`Modifier named ${name} is already defined`)
+
+    eventModifiers[name] = fn
+    return this
+  }
+
+  /**
+   * Initialize Beskydy. It starts by collecting all the scopes and initializing them
+   */
   init() {
     const scopeRoots = Array.from(document.querySelectorAll('[x-scope]'))
     for (const scopeRoot of scopeRoots)


### PR DESCRIPTION
Add the option to provide parameters for event modifiers. For now it will only support one parameter, as there seems to be attribute parsing issues if an attribute name includes a comma.

Added some new modifiers

- `only[n]` will execute provided callback n times
- `throttle[n]`
- `if[value]` executes if value is truthy, also accepts primitive variables defined in scope

