### PR TITLE
Add `teardown()` to app root and context

### DIFF
--- a/dist/beskydy.mjs
+++ b/dist/beskydy.mjs
@@ -1,18 +1,23 @@
 var F = Object.defineProperty;
 var K = (e, t, r) => t in e ? F(e, t, { enumerable: !0, configurable: !0, writable: !0, value: r }) : e[t] = r;
 var A = (e, t, r) => (K(e, typeof t != "symbol" ? t + "" : t, r), r);
-import { reactive as L, effect as q } from "@vue/reactivity";
-class S {
+import { reactive as S, effect as q } from "@vue/reactivity";
+class W {
   constructor(t, r) {
     // Store the context root element
     A(this, "root");
     // Reactive dataset available to the entire scope
     A(this, "data");
     A(this, "init");
-    // Watch effects
-    // effect = rawEffect
-    A(this, "effect", q);
-    this.root = t, this.data = L(Object.assign({ $refs: {} }, P, r)), this.init = !1;
+    // Hold all context runners for disposal
+    A(this, "effects", []);
+    this.root = t, this.data = S(Object.assign({ $refs: {} }, _, r)), this.init = !1;
+  }
+  // Watch effects
+  // effect = rawEffect
+  effect(t) {
+    const r = q(t);
+    this.effects.push(r);
   }
   // Store refs for access within scope
   addRef(t, r) {
@@ -24,19 +29,23 @@ class S {
     Object.assign(this.data, t.data);
   }
   teardown() {
+    var r;
+    this.effects.forEach((n) => n.effect.stop()), this.effects.length = 0;
+    const t = this.root.cloneNode(!0);
+    (r = this.root.parentElement) == null || r.replaceChild(t, this.root), Reflect.set(this, "data", /* @__PURE__ */ Object.create(null)), this.init = !1;
   }
 }
-const v = {}, I = /* @__PURE__ */ Object.create(null);
+const v = {}, L = /* @__PURE__ */ Object.create(null);
 function m(e, t, r) {
-  return W(e, `return(${t})`, r);
+  return D(e, `return(${t})`, r);
 }
-function W(e, t, r, n) {
+function D(e, t, r, n) {
   JSON.stringify(e);
-  const s = I[t] || (I[t] = H(t));
+  const s = L[t] || (L[t] = H(t));
   try {
     return s(e, r, n);
-  } catch (a) {
-    console.error(a);
+  } catch (o) {
+    console.error(o);
   }
 }
 function H(e) {
@@ -51,13 +60,13 @@ function O(e, t) {
   const r = e.attributes.getNamedItem(t);
   return r ? (e.removeAttribute(t), r.value ?? !0) : null;
 }
-function T(e) {
+function R(e) {
   return e == null;
 }
 function j(e) {
   return !!e && e.constructor === Object;
 }
-const D = Array.isArray;
+const M = Array.isArray;
 function U(e) {
   for (; e.lastElementChild; )
     e.removeChild(e.lastElementChild);
@@ -84,10 +93,10 @@ const z = function(e, t, { value: r, name: n }) {
   t.removeAttribute(n);
   const s = r;
   e.effect(() => {
-    const a = m(e.data, s, t);
-    if (j(a))
-      for (const l of Object.keys(a))
-        Reflect.has(t, "style") && Reflect.set(t.style, l, a[l]);
+    const o = m(e.data, s, t);
+    if (j(o))
+      for (const l of Object.keys(o))
+        Reflect.has(t, "style") && Reflect.set(t.style, l, o[l]);
   });
 }, X = function(e, t, { value: r, name: n }) {
   t.removeAttribute(n);
@@ -103,35 +112,35 @@ const z = function(e, t, { value: r, name: n }) {
   });
 }, Y = function(e, t, { name: r, value: n }) {
   t.removeAttribute(r);
-  const [s, a] = r.split(":"), l = (i, o) => {
-    T(o) ? t.removeAttribute(i) : t.setAttribute(i, o);
+  const [s, o] = r.split(":"), l = (i, a) => {
+    R(a) ? t.removeAttribute(i) : t.setAttribute(i, a);
   };
-  a ? e.effect(() => {
+  o ? e.effect(() => {
     const i = m(e.data, n, t);
     l(r, i);
   }) : e.effect(() => {
     const i = m(e.data, n, t) ?? {};
-    for (const o of Object.keys(i)) {
-      const u = i[o];
-      l(o, u);
+    for (const a of Object.keys(i)) {
+      const u = i[a];
+      l(a, u);
     }
   });
 }, Z = function(e, t, { value: r }) {
   const n = (s) => {
-    for (const a of Object.keys(s))
-      s[a] ? t.classList.add(a) : t.classList.remove(a);
+    for (const o of Object.keys(s))
+      s[o] ? t.classList.add(o) : t.classList.remove(o);
   };
   if (r.startsWith("[")) {
     const s = /* @__PURE__ */ Object.create(null);
     e.effect(() => {
-      const a = m(e.data, r);
-      for (let l = 0; l < a.length; l++) {
-        const i = a[l];
+      const o = m(e.data, r);
+      for (let l = 0; l < o.length; l++) {
+        const i = o[l];
         if (i)
           typeof i == "string" ? (t.classList.add(i), s[l] = i) : j(i) && n(i);
         else {
-          const o = s[l];
-          o && (t.classList.remove(o), s[l] = null);
+          const a = s[l];
+          a && (t.classList.remove(a), s[l] = null);
         }
       }
     });
@@ -160,40 +169,40 @@ const z = function(e, t, { value: r, name: n }) {
   stopImmediate: (e) => (e.stopImmediatePropagation(), !0)
 }, ee = function(e, t, { name: r, value: n }) {
   t.removeAttribute(r);
-  const s = (r.startsWith("x-on") ? r.split(":")[1] : r.substring(1)).split("."), a = s[0], l = s.slice(1).map((o) => {
-    const [u, p] = o.split("[");
-    let b;
+  const s = (r.startsWith("x-on") ? r.split(":")[1] : r.substring(1)).split("."), o = s[0], l = s.slice(1).map((a) => {
+    const [u, p] = a.split("[");
+    let h;
     if (p) {
       const c = p.replace("]", "");
-      b = E(c, e);
+      h = E(c, e);
     }
-    return { key: u, param: b };
-  }).filter((o) => Object.keys(N).includes(o.key));
+    return { key: u, param: h };
+  }).filter((a) => Object.keys(N).includes(a.key));
   n.startsWith("()") && (n = `(${n})()`);
   const i = {
     calledTimes: 0,
     lastCall: 0
   };
-  t.addEventListener(a, (o) => {
-    l.every((u) => N[u.key](o, i, u.param)) && (W(e.data, n, t, o), i.calledTimes++, i.lastCall = Date.now());
+  t.addEventListener(o, (a) => {
+    l.every((u) => N[u.key](a, i, u.param)) && (D(e.data, n, t, a), i.calledTimes++, i.lastCall = Date.now());
   });
 }, te = function(e, t, { name: r, value: n }) {
   t.removeAttribute(r);
-  const s = t.parentElement, a = new Comment("x-if");
-  s.insertBefore(a, t);
+  const s = t.parentElement, o = new Comment("x-if");
+  s.insertBefore(o, t);
   const l = [{
     node: t,
     expr: n
   }];
-  let i, o;
-  for (; (i = t.nextElementSibling) !== null && ((o = O(i, "x-else")) !== null || (o = O(i, "x-else-if"))); )
+  let i, a;
+  for (; (i = t.nextElementSibling) !== null && ((a = O(i, "x-else")) !== null || (a = O(i, "x-else-if"))); )
     l.push({
       node: i,
-      expr: o
+      expr: a
     }), s.removeChild(i);
   s.removeChild(t);
   let u, p;
-  function b() {
+  function h() {
     p && (s.removeChild(p.node), p = null);
   }
   e.effect(() => {
@@ -201,28 +210,28 @@ const z = function(e, t, { value: r, name: n }) {
     for (let c = 0; c < l.length; c++) {
       const f = l[c];
       if (!f.expr || m(e.data, f.expr, t)) {
-        u !== c && (p && b(), s.insertBefore(f.node, a), console.log(f.node), C(e, f.node), p = f, u = c);
+        u !== c && (p && h(), s.insertBefore(f.node, o), console.log(f.node), C(e, f.node), p = f, u = c);
         return;
       }
     }
-    u = -1, b();
+    u = -1, h();
   });
-}, R = {
+}, T = {
   trim: (e) => e.trim(),
   number: (e, t) => Number.isNaN(Number(e)) ? Number(t) : Number(e)
 }, re = function(e, t, { name: r, value: n }) {
-  var p, b;
+  var p, h;
   let s = t;
-  const [a, l] = r.split("."), i = (p = s.attributes.getNamedItem("value")) == null ? void 0 : p.value, o = (c, f) => {
+  const [o, l] = r.split("."), i = (p = s.attributes.getNamedItem("value")) == null ? void 0 : p.value, a = (c, f) => {
     if (!l)
       return c;
-    const [d, h] = l.split("[");
+    const [d, b] = l.split("[");
     let g;
-    if (h) {
-      const y = h.replace("]", "");
+    if (b) {
+      const y = b.replace("]", "");
       g = E(y, e);
     }
-    return R[d](c, f, g);
+    return T[d](c, f, g);
   }, u = () => {
     let c;
     const f = m(e.data, n);
@@ -231,14 +240,14 @@ const z = function(e, t, { value: r, name: n }) {
   switch (s.tagName) {
     case "INPUT":
     case "TEXTAREA": {
-      switch (s = s, (b = s.attributes.getNamedItem("type")) == null ? void 0 : b.value) {
+      switch (s = s, (h = s.attributes.getNamedItem("type")) == null ? void 0 : h.value) {
         case "checkbox": {
-          const c = Reflect.get(e.data, n), f = (d, h) => {
-            D(c) ? c.includes(d) ? c.splice(c.indexOf(d), 1) : c.push(d) : Reflect.set(e.data, d, T(d) ? !h : d);
+          const c = Reflect.get(e.data, n), f = (d, b) => {
+            M(c) ? c.includes(d) ? c.splice(c.indexOf(d), 1) : c.push(d) : Reflect.set(e.data, d, R(d) ? !b : d);
           };
           (!c || c.length === 0) && s.hasAttribute("checked") && (f(s.value, !0), s.removeAttribute("checked")), s.addEventListener("change", (d) => {
-            const { checked: h, value: g } = d == null ? void 0 : d.target;
-            f(g, h);
+            const { checked: b, value: g } = d == null ? void 0 : d.target;
+            f(g, b);
           }), e.effect(() => {
             s = s;
             const d = m(e.data, n);
@@ -259,8 +268,8 @@ const z = function(e, t, { value: r, name: n }) {
         }
         default:
           u(), s.removeAttribute("x-model"), s.addEventListener("input", (c) => {
-            const f = c.target, d = f.value, h = o(d, Reflect.get(e.data, n));
-            d !== h && (f.value = String(h)), Object.assign(e.data, { [n]: h });
+            const f = c.target, d = f.value, b = a(d, Reflect.get(e.data, n));
+            d !== b && (f.value = String(b)), Object.assign(e.data, { [n]: b });
           }), e.effect(() => s.value = m(e.data, n));
       }
       break;
@@ -275,83 +284,83 @@ const z = function(e, t, { value: r, name: n }) {
     case "DETAILS": {
       s = s;
       const c = s.attributes.getNamedItem("open"), f = m(e.data, n);
-      s.open = T(f) ? c ?? !1 : f, s.addEventListener("toggle", (d) => {
-        const h = d.target.open;
-        Object.assign(e.data, { [n]: h });
+      s.open = R(f) ? c ?? !1 : f, s.addEventListener("toggle", (d) => {
+        const b = d.target.open;
+        Object.assign(e.data, { [n]: b });
       }), e.effect(() => s.open = m(e.data, n));
       break;
     }
   }
 }, se = function(e, t, { value: r, name: n }) {
   t.removeAttribute(n), t.removeAttribute("x-if");
-  const [s, a, l] = r.split(/(?!\(.*)\s(?![^(]*?\))/g), i = t.parentElement, o = t.cloneNode(!0);
+  const [s, o, l] = r.split(/(?!\(.*)\s(?![^(]*?\))/g), i = t.parentElement, a = t.cloneNode(!0);
   t.remove();
   const u = () => {
-    const b = o.cloneNode(!0), c = new S(b);
-    return c.extend(e), { newEl: b, newCtx: c };
-  }, p = (b, c) => {
-    i == null || i.appendChild(b), C(c);
+    const h = a.cloneNode(!0), c = new W(h);
+    return c.extend(e), { newEl: h, newCtx: c };
+  }, p = (h, c) => {
+    i == null || i.appendChild(h), C(c);
   };
   e.effect(() => {
-    const b = m(e.data, l);
-    if (typeof b == "number") {
+    const h = m(e.data, l);
+    if (typeof h == "number") {
       U(i);
-      for (const c in Array.from({ length: b })) {
+      for (const c in Array.from({ length: h })) {
         const { newEl: f, newCtx: d } = u();
         Object.assign(d.data, { [s]: Number(c) }), p(f, d);
       }
-    } else if (D(b)) {
-      const [c, f] = s.replace("(", "").replace(")", "").split(","), d = c.trim(), h = f == null ? void 0 : f.trim();
-      b.forEach((g, y) => {
+    } else if (M(h)) {
+      const [c, f] = s.replace("(", "").replace(")", "").split(","), d = c.trim(), b = f == null ? void 0 : f.trim();
+      h.forEach((g, y) => {
         const { newEl: x, newCtx: w } = u();
-        Object.assign(w.data, { [d]: g }), h && Object.assign(w.data, { [h]: Number(y) }), p(x, w);
+        Object.assign(w.data, { [d]: g }), b && Object.assign(w.data, { [b]: Number(y) }), p(x, w);
       });
-    } else if (j(b)) {
-      const [c, f, d] = s.replace("(", "").replace(")", "").split(","), h = c.trim(), g = f == null ? void 0 : f.trim(), y = d == null ? void 0 : d.trim();
-      Object.entries(b).forEach(([x, w], $) => {
+    } else if (j(h)) {
+      const [c, f, d] = s.replace("(", "").replace(")", "").split(","), b = c.trim(), g = f == null ? void 0 : f.trim(), y = d == null ? void 0 : d.trim();
+      Object.entries(h).forEach(([x, w], $) => {
         const { newEl: B, newCtx: k } = u();
-        Object.assign(k.data, { [h]: w }), g && Object.assign(k.data, { [g]: x }), y && Object.assign(k.data, { [y]: Number($) }), p(B, k);
+        Object.assign(k.data, { [b]: w }), g && Object.assign(k.data, { [g]: x }), y && Object.assign(k.data, { [y]: Number($) }), p(B, k);
       });
     } else
       throw new TypeError("Unsupported value was used in 'x-for'. Please only use a number, array or an object");
   });
 };
-function M(e, t) {
+function V(e, t) {
   if (!t.textContent || t.textContent === "")
     return;
   const r = t.textContent, n = new RegExp("(?=\\{\\{)(.*?)(?<=\\}\\})", "g"), s = r.match(n);
   !s || s.length === 0 || e.effect(() => {
-    let a = r;
+    let o = r;
     for (const l of s) {
       const i = l.replace("{{", "").replace("}}", "");
       if (!i)
         continue;
-      const o = m(e.data, i, t);
-      a = a.replace(l, o);
+      const a = m(e.data, i, t);
+      o = o.replace(l, a);
     }
-    t.textContent = a;
+    t.textContent = o;
   });
 }
 const ne = function(e, t, { name: r, value: n }) {
-  const s = t.cloneNode(!0), a = document.querySelector(n), [, l] = r.split(":");
-  if (!a) {
+  const s = t.cloneNode(!0), o = document.querySelector(n), [, l] = r.split(":");
+  if (!o) {
     console.error("No valid target provided for `x-portal`");
     return;
   }
-  t.remove(), l === "prepend" ? a.prepend(s) : l === "replace" ? a.replaceChildren(s) : a.append(s);
+  t.remove(), l === "prepend" ? o.prepend(s) : l === "replace" ? o.replaceChildren(s) : o.append(s);
   const i = document.createTreeWalker(s);
-  let o = i.root;
-  for (; o; ) {
-    if (o.nodeType === 1) {
-      const u = o;
+  let a = i.root;
+  for (; a; ) {
+    if (a.nodeType === 1) {
+      const u = a;
       if (O(u, "x-skip") !== null) {
-        o = i.nextSibling();
+        a = i.nextSibling();
         continue;
       }
-      V(e, u);
+      P(e, u);
     } else
-      o.nodeType === 3 && M(e, o);
-    o = i.nextNode();
+      a.nodeType === 3 && V(e, a);
+    a = i.nextNode();
   }
 }, ie = function(e, t, { name: r, value: n }) {
   if (t.removeAttribute(r), r === "x-scope" && e.root !== t)
@@ -362,9 +371,9 @@ const ne = function(e, t, { name: r, value: n }) {
     const s = m({}, n);
     if (!j(s))
       return !0;
-    for (const a of Object.keys(s))
-      Object.defineProperty(e.data, a, {
-        value: s[a],
+    for (const o of Object.keys(s))
+      Object.defineProperty(e.data, o, {
+        value: s[o],
         writable: !0,
         enumerable: !0,
         configurable: !0
@@ -373,51 +382,51 @@ const ne = function(e, t, { name: r, value: n }) {
     return console.warn("[x-scope/x-data] Error when processing attribute"), console.log(s), !0;
   }
   return !1;
-}, ae = function(e, t, { value: r }) {
+}, oe = function(e, t, { value: r }) {
   t.removeAttribute("x-switch");
   const n = [], s = Array.from(t.children).filter((i) => i.hasAttribute("x-case") || i.hasAttribute("x-default")).map((i) => {
-    var o;
+    var a;
     return {
       isDefault: i.hasAttribute("x-default"),
       isCase: i.hasAttribute("x-case"),
-      expr: ((o = i.attributes.getNamedItem("x-case")) == null ? void 0 : o.value) ?? null,
+      expr: ((a = i.attributes.getNamedItem("x-case")) == null ? void 0 : a.value) ?? null,
       node: i
     };
   }).map((i) => {
-    const o = new Comment("x-switch");
-    return t.insertBefore(o, i.node), n.push(o), i.node.removeAttribute("x-case"), i.node.removeAttribute("x-default"), i.node.remove(), i;
+    const a = new Comment("x-switch");
+    return t.insertBefore(a, i.node), n.push(a), i.node.removeAttribute("x-case"), i.node.removeAttribute("x-default"), i.node.remove(), i;
   });
-  let a;
+  let o;
   function l() {
-    a && (a.node.remove(), a = null);
+    o && (o.node.remove(), o = null);
   }
   e.effect(() => {
     const i = m(e.data, r);
-    let o;
+    let a;
     for (let u = 0; u < s.length; u++) {
       const p = s[u];
-      if (u < s.length - 1 && p.isDefault && (o = [p, u]), p.expr) {
+      if (u < s.length - 1 && p.isDefault && (a = [p, u]), p.expr) {
         if (E(p.expr, e) === i) {
-          o = [p, u];
+          a = [p, u];
           break;
         }
       } else
-        u === s.length - 1 && (o = [p, u]);
+        u === s.length - 1 && (a = [p, u]);
     }
-    if (o) {
+    if (a) {
       l();
-      const [u, p] = o, b = n[p];
-      t.insertBefore(u.node, b), C(e, u.node), a = u;
+      const [u, p] = a, h = n[p];
+      t.insertBefore(u.node, h), C(e, u.node), o = u;
       return;
     }
     l();
   });
-}, oe = function(e, t, { name: r, value: n }) {
-  const [s, ...a] = r.split(":");
+}, ae = function(e, t, { name: r, value: n }) {
+  const [s, ...o] = r.split(":");
   let l = /* @__PURE__ */ Object.create(null);
   e.effect(() => {
-    if (a.length > 0) {
-      for (const i of a)
+    if (o.length > 0) {
+      for (const i of o)
         if (Reflect.get(l, i) !== Reflect.get(e.data, i)) {
           m(e.data, n, t);
           break;
@@ -437,27 +446,27 @@ function C(e, t) {
         n = r.nextSibling();
         continue;
       }
-      let a;
-      (a = Array.from(s.attributes).find((l) => l.name.startsWith("x-portal"))) && ne(e, s, a), V(e, s);
+      let o;
+      (o = Array.from(s.attributes).find((l) => l.name.startsWith("x-portal"))) && ne(e, s, o), P(e, s);
     } else
-      n.nodeType === 3 && M(e, n);
+      n.nodeType === 3 && V(e, n);
     n = r.nextNode();
   }
 }
-function V(e, t) {
+function P(e, t) {
   for (const r of Array.from(t.attributes)) {
     if ((r.name === "x-data" || r.name === "x-scope") && ie(e, t, r))
       throw new Error(`[x-scope/x-data] Error when processing attribute. 
  Most likely an issue with the the data object.`);
-    r.name === "x-for" ? se(e, t, r) : r.name === "x-if" && te(e, t, r), r.name === "x-switch" && ae(e, t, r), r.name === "x-ref" && z(e, t, r), r.name.startsWith("x-model") && re(e, t, r), (r.name.startsWith("x-bind") || r.name.startsWith(":")) && Y(e, t, r), (r.name.startsWith("@") || r.name.startsWith("x-on")) && ee(e, t, r), r.name.startsWith("x-spy") && oe(e, t, r), r.name === "x-text" && G(e, t, r), r.name === "x-class" && Z(e, t, r), r.name === "x-html" && Q(e, t, r), r.name === "x-style" && J(e, t, r), r.name === "x-show" && X(e, t, r), Object.keys(v).length > 0 && Object.entries(v).forEach(([n, s]) => {
+    r.name === "x-for" ? se(e, t, r) : r.name === "x-if" && te(e, t, r), r.name === "x-switch" && oe(e, t, r), r.name === "x-ref" && z(e, t, r), r.name.startsWith("x-model") && re(e, t, r), (r.name.startsWith("x-bind") || r.name.startsWith(":")) && Y(e, t, r), (r.name.startsWith("@") || r.name.startsWith("x-on")) && ee(e, t, r), r.name.startsWith("x-spy") && ae(e, t, r), r.name === "x-text" && G(e, t, r), r.name === "x-class" && Z(e, t, r), r.name === "x-html" && Q(e, t, r), r.name === "x-style" && J(e, t, r), r.name === "x-show" && X(e, t, r), Object.keys(v).length > 0 && Object.entries(v).forEach(([n, s]) => {
       r.name.startsWith(n) && s(e, t, r);
     });
   }
 }
-const P = L({}), _ = [];
+const _ = S({}), I = [];
 class ce {
   constructor(t) {
-    Object.assign(P, t);
+    Object.assign(_, t);
   }
   /**
    * Add a custom directive (element attribute)
@@ -488,9 +497,9 @@ class ce {
    * @param fn Modifier implementation
    */
   static defineModelModifier(t, r) {
-    if (t in R)
+    if (t in T)
       throw new Error(`Model modifier ${t} is already defined`);
-    return R[t] = r, this;
+    return T[t] = r, this;
   }
   /**
    * Initialize Beskydy. It starts by collecting all the scopes and initializing them
@@ -500,22 +509,25 @@ class ce {
     for (const r of t)
       le(r);
   }
-  // TODO
-  // Remove everything
+  /**
+   * Stops Beskydy instance, removes reactivity and event listeners and leaves the DOM in the state it was when the app was torn down./
+   */
   teardown() {
-    for (const t of _)
+    for (const t of I)
       t.teardown();
+    I.length = 0;
   }
 }
 function de(e) {
   return new ce(e ?? {});
 }
 function le(e) {
-  const t = new S(e);
-  return e.setAttribute("style", "display:none;"), C(t), t.init = !0, e.removeAttribute("style"), _.push(t), { ctx: t };
+  const t = new W(e);
+  return e.setAttribute("style", "display:none;"), C(t), t.init = !0, e.removeAttribute("style"), I.push(t), { ctx: t };
 }
 export {
   ce as Beskydy,
   de as createApp,
-  le as createScope
+  le as createScope,
+  _ as globalState
 };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-import { effect } from '@vue/reactivity';
+import type { ReactiveEffectRunner } from '@vue/reactivity';
 import type { UnwrapNestedRefs } from '@vue/reactivity';
 
 export declare class Beskydy<T extends object> {
@@ -28,6 +28,9 @@ export declare class Beskydy<T extends object> {
      * Initialize Beskydy. It starts by collecting all the scopes and initializing them
      */
     start(): void;
+    /**
+     * Stops Beskydy instance, removes reactivity and event listeners and leaves the DOM in the state it was when the app was torn down./
+     */
     teardown(): void;
 }
 
@@ -35,8 +38,9 @@ declare class Context<R extends Element, T extends object> {
     root: Element;
     data: UnwrapNestedRefs<T & ContextData>;
     init: boolean;
+    effects: ReactiveEffectRunner[];
     constructor(root: R, initialDataset?: T);
-    effect: typeof effect;
+    effect(fn: () => any): void;
     addRef(key: string, ref: Element): void;
     extend(ctx: ContextAny): void;
     teardown(): void;
@@ -61,7 +65,7 @@ export declare type Directive<T = void> = (ctx: ContextAny, node: Element, attr:
 
 export declare type EventModifierFn = (e: Event, state: ModifierListenerState, parameter: Primitive) => boolean;
 
-declare const globalState: {};
+export declare const globalState: {};
 
 export declare type ModelModifierFn = (value: string, oldValue: string, param?: unknown) => unknown;
 

--- a/index.html
+++ b/index.html
@@ -29,12 +29,13 @@
   <body>
     <div id="app">
       <div x-scope="{ first: 1, second: 10 }">
-        <span x-funny=""></span>
-        <!-- <button @click="first++">Increment First</button>
+        <button @click="first++">Increment First</button>
         <button @click="second++">Increment Second</button>
 
         <div x-spy:first="console.log('Updated first', first, second)"></div>
-        <div x-spy:nested="console.log('Updated third', nested.third)"></div> -->
+        <div x-spy:second="console.log('Updated second', second)"></div>
+
+        <span>{{first}}</span>
       </div> 
     </div>
     <script type="module" src="./src/index.ts"></script>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <div x-spy:first="console.log('Updated first', first, second)"></div>
         <div x-spy:second="console.log('Updated second', second)"></div>
 
-        <span>{{first}}</span>
+        <span>{{ first }}</span>
       </div> 
     </div>
     <script type="module" src="./src/index.ts"></script>

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,28 +2,6 @@ import type { ReactiveEffectRunner, UnwrapNestedRefs } from '@vue/reactivity'
 import { effect as rawEffect, reactive } from '@vue/reactivity'
 import { globalState } from './scope'
 
-// let queued = false
-// const queue: Function[] = []
-// const p = Promise.resolve()
-
-// export const nextTick = (fn: () => void) => p.then(fn)
-
-// export const queueJob = (job: Function) => {
-//   if (!queue.includes(job)) queue.push(job)
-//   if (!queued) {
-//     queued = true
-//     nextTick(flushJobs)
-//   }
-// }
-
-// const flushJobs = () => {
-//   for (const job of queue) {
-//     job()
-//   }
-//   queue.length = 0
-//   queued = false
-// }
-
 export type ContextAny = Context<Element, object>
 
 /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -72,8 +72,7 @@ export class Context<R extends Element, T extends object> {
   teardown() {
     // Iterate over all children of a ctx and remove any beskydy functionality
     this.effects.forEach(e => e.effect.stop())
-
-    Reflect.set(this, 'effects', [])
+    this.effects.length = 0
 
     // Clone whole subtree and re-attach it to the parent. This removes any event listeners
     const clone = this.root.cloneNode(true)

--- a/src/context.ts
+++ b/src/context.ts
@@ -42,7 +42,7 @@ export class Context<R extends Element, T extends object> {
   // Reactive dataset available to the entire scope
   data: UnwrapNestedRefs<T & ContextData>
   init: boolean
-
+  // Hold all context runners for disposal
   effects: ReactiveEffectRunner[] = []
 
   constructor(root: R, initialDataset?: T) {
@@ -53,7 +53,10 @@ export class Context<R extends Element, T extends object> {
 
   // Watch effects
   // effect = rawEffect
-  effect = rawEffect
+  effect(fn: () => any) {
+    const handler = rawEffect(fn)
+    this.effects.push(handler)
+  }
 
   // Store refs for access within scope
   addRef(key: string, ref: Element) {

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -20,4 +20,8 @@ export interface Modifier {
   param: Primitive
 }
 
-export type EventModifierFn = (e: Event, state: ModifierListenerState, parameter: Primitive) => boolean
+export type EventModifierFn = (
+  e: Event,
+  state: ModifierListenerState,
+  parameter: Primitive
+) => boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
   createScope,
   Beskydy,
   createApp,
+  globalState,
 } from './scope'
 
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { createApp } from './scope'
-
 export {
   createScope,
   Beskydy,
@@ -16,10 +14,3 @@ export type {
 export type {
   ModelModifierFn,
 } from './directives/x-model'
-
-const app = createApp()
-app.start()
-
-setTimeout(() => {
-  app.teardown()
-}, 1000)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { createApp } from './scope'
+
 export {
   createScope,
   Beskydy,
@@ -13,3 +15,10 @@ export type {
 export type {
   ModelModifierFn,
 } from './directives/x-model'
+
+const app = createApp()
+app.start()
+
+setTimeout(() => {
+  app.teardown()
+}, 1000)

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -8,7 +8,13 @@ import { eventModifiers } from './directives/x-on'
 import type { ModelModifierFn } from './directives/x-model'
 import { modelModifiers } from './directives/x-model'
 
+/**
+ * Shared global state between all scopes.
+ *
+ * Extend ugins `Object.assign(globalState, { ...yourProperties })`
+ */
 export const globalState = reactive({})
+
 const scopes: ContextAny[] = []
 
 export class Beskydy<T extends object> {

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -64,11 +64,14 @@ export class Beskydy<T extends object> {
       createScope(scopeRoot)
   }
 
-  // TODO
-  // Remove everything
+  /**
+   * Stops Beskydy instance, removes reactivity and event listeners and leaves the DOM in the state it was when the app was torn down./
+   */
   teardown() {
     for (const ctx of scopes)
       ctx.teardown()
+
+    scopes.length = 0
   }
 }
 
@@ -82,8 +85,6 @@ export function createScope(scopeRoot: Element) {
   walk(ctx)
   ctx.init = true
   scopeRoot.removeAttribute('style')
-
   scopes.push(ctx)
-
   return { ctx }
 }


### PR DESCRIPTION
This allows us the stop the application from running. This will remove all event listeners, reset global state and stop any reactivity in the app. Essentially removes `Beskydy` and leaves DOM looking the way it was, when teardown was called.